### PR TITLE
Add crypto dashboard

### DIFF
--- a/src/app/crypto/page.tsx
+++ b/src/app/crypto/page.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useState } from "react"
+import { Plus } from "@phosphor-icons/react"
+import { Button } from "@radix-ui/themes"
+import Paper from "@src/components/Paper"
+import { cn } from "@src/utils/cn"
+
+interface WalletItem {
+  symbol: string
+  name: string
+  balance: number
+  fiatValue: number
+  dailyChange: number
+}
+
+const demoWallets: WalletItem[] = [
+  { symbol: "BTC", name: "Bitcoin", balance: 0.5, fiatValue: 30000, dailyChange: 1.2 },
+  { symbol: "ETH", name: "Ethereum", balance: 10, fiatValue: 25000, dailyChange: -0.5 },
+  { symbol: "USDT", name: "Tether", balance: 2000, fiatValue: 2000, dailyChange: 0.0 },
+]
+
+export default function CryptoPage() {
+  const [showBalance, setShowBalance] = useState(true)
+
+  const totalCrypto = demoWallets.reduce((acc, w) => acc + w.fiatValue, 0)
+
+  return (
+    <Paper>
+      <div className="flex flex-col gap-4">
+        {/* Header with tabs */}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-xl font-bold text-gray-12">Crypto</h1>
+          <div className="flex gap-4">
+            <Tab active>Portfolio</Tab>
+            <Tab>Summary</Tab>
+            <Tab>Coins</Tab>
+          </div>
+        </div>
+
+        {/* Total crypto widget */}
+        <div className="flex items-center justify-between bg-gray-3 rounded-xl p-4">
+          <div className="flex flex-col">
+            <span className="text-sm text-gray-11">Total crypto</span>
+            <span className="text-2xl font-bold text-gray-12">
+              {showBalance ? `$${totalCrypto.toLocaleString()}` : "******"}
+            </span>
+          </div>
+          <Button
+            size="2"
+            variant="ghost"
+            onClick={() => setShowBalance((v) => !v)}
+            className="ml-2"
+          >
+            {showBalance ? "Hide" : "Show"}
+          </Button>
+        </div>
+
+        {/* Wallet list */}
+        <div className="flex flex-col gap-2">
+          {demoWallets.map((w) => (
+            <WalletRow key={w.symbol} item={w} />
+          ))}
+        </div>
+
+        {/* Staking placeholder */}
+        <div className="mt-4">
+          <h2 className="text-lg font-bold mb-2 text-gray-12">Staking</h2>
+          <div className="flex items-center justify-between bg-gray-3 rounded-xl p-4">
+            <span className="text-gray-11">Coming soon</span>
+            <Plus className="text-gray-11" />
+          </div>
+        </div>
+      </div>
+    </Paper>
+  )
+}
+
+function Tab({ children, active }: { children: React.ReactNode; active?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "text-sm font-medium cursor-pointer",
+        active ? "text-gray-12" : "text-gray-10"
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+function WalletRow({ item }: { item: WalletItem }) {
+  return (
+    <div className="flex items-center justify-between bg-gray-2 rounded-xl p-3">
+      <div className="flex items-center gap-3">
+        <div className="w-6 h-6 rounded-full bg-gray-5 flex items-center justify-center text-xs font-bold text-gray-12">
+          {item.symbol}
+        </div>
+        <div className="flex flex-col">
+          <span className="text-gray-12 font-medium text-sm">{item.name}</span>
+          <span className="text-gray-11 text-xs">
+            {item.balance} {item.symbol}
+          </span>
+        </div>
+      </div>
+      <div className="text-right">
+        <span className="text-gray-12 font-medium text-sm block">
+          ${item.fiatValue.toLocaleString()}
+        </span>
+        <span
+          className={cn(
+            "text-xs",
+            item.dailyChange >= 0 ? "text-green-9" : "text-red-9"
+          )}
+        >
+          {item.dailyChange >= 0 ? "+" : ""}
+          {item.dailyChange}%
+        </span>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/Navbar/NavbarDesktop.tsx
+++ b/src/components/Navbar/NavbarDesktop.tsx
@@ -12,6 +12,7 @@ export function NavbarDesktop() {
 
   const isAccountActive = isActive(navigation.account)
   const isTradeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isCryptoActive = isActive(navigation.crypto)
 
   return (
     <nav className="flex justify-between items-center gap-4">
@@ -24,6 +25,9 @@ export function NavbarDesktop() {
 
       {/* Trade */}
       <NavItem label="Trade" isActive={isTradeActive} href={navigation.home} />
+
+      {/* Crypto */}
+      <NavItem label="Crypto" isActive={isCryptoActive} href={navigation.crypto} />
     </nav>
   )
 }

--- a/src/components/Navbar/NavbarMobile.tsx
+++ b/src/components/Navbar/NavbarMobile.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowsLeftRight, Plus } from "@phosphor-icons/react"
+import { CurrencyCircleDollar, House, Plus } from "@phosphor-icons/react"
 import { navigation } from "@src/constants/routes"
 import { useIsActiveLink } from "@src/hooks/useIsActiveLink"
 import { cn } from "@src/utils/cn"
@@ -12,36 +12,43 @@ export function NavbarMobile() {
   const { isActive } = useIsActiveLink()
 
   const isAccountActive = isActive(navigation.account)
-  const isTradeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isHomeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isCryptoActive = isActive(navigation.crypto)
   const isDepositActive = isActive(navigation.deposit)
 
   return (
     <>
       <div className="fixed bottom-0 z-50 left-0 md:hidden w-full px-5 pt-3 pb-[max(env(safe-area-inset-bottom,0px),theme(spacing.3))] bg-gray-1 border-t-[1px] border-gray-a3">
         <nav className="flex justify-around items-center gap-4">
-          {/* Account */}
+          {/* Home */}
           <NavItem
-            href={navigation.account}
-            label="Account"
-            isActive={isAccountActive}
+            href={navigation.home}
+            label="Home"
+            isActive={isHomeActive}
             iconSlot={
               <NavItem.DisplayIcon>
-                {<WalletIcon active={isAccountActive} />}
+                <House
+                  className={cn(
+                    "size-4",
+                    isHomeActive ? "text-gray-12" : "text-gray-11"
+                  )}
+                  weight="bold"
+                />
               </NavItem.DisplayIcon>
             }
           />
 
-          {/* Trade */}
+          {/* Crypto */}
           <NavItem
-            href={navigation.home}
-            label="Trade"
-            isActive={isTradeActive}
+            href={navigation.crypto}
+            label="Crypto"
+            isActive={isCryptoActive}
             iconSlot={
               <NavItem.DisplayIcon>
-                <ArrowsLeftRight
+                <CurrencyCircleDollar
                   className={cn(
                     "size-4",
-                    isTradeActive ? "text-gray-12" : "text-gray-11"
+                    isCryptoActive ? "text-gray-12" : "text-gray-11"
                   )}
                   weight="bold"
                 />
@@ -66,6 +73,18 @@ export function NavbarMobile() {
                     <Plus className="size-3 text-gray-1" weight="bold" />
                   </div>
                 }
+              </NavItem.DisplayIcon>
+            }
+          />
+
+          {/* Wallet */}
+          <NavItem
+            href={navigation.account}
+            label="Wallet"
+            isActive={isAccountActive}
+            iconSlot={
+              <NavItem.DisplayIcon>
+                {<WalletIcon active={isAccountActive} />}
               </NavItem.DisplayIcon>
             }
           />

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,6 +3,7 @@ export const navigation = {
   account: "/account",
   deposit: "/deposit",
   withdraw: "/withdraw",
+  crypto: "/crypto",
   otc: "/otc/create-order",
   jobs: "/jobs",
 } satisfies Record<AppRoutes, string>
@@ -12,5 +13,6 @@ export type AppRoutes =
   | "account"
   | "deposit"
   | "withdraw"
+  | "crypto"
   | "otc"
   | "jobs"


### PR DESCRIPTION
## Summary
- add route constants for `/crypto`
- implement `/crypto` page showing portfolio balance and wallet list
- update mobile and desktop navbars with new Crypto link

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn check` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6886a4e2c1c0833180170123eb41671e