### PR TITLE
Add crypto screen and dark theme

### DIFF
--- a/src/app/crypto/layout.tsx
+++ b/src/app/crypto/layout.tsx
@@ -1,0 +1,17 @@
+import Layout from "@src/components/Layout"
+import { PreloadFeatureFlags } from "@src/components/PreloadFeatureFlags"
+import { settings } from "@src/config/settings"
+import type { Metadata } from "next"
+import type { ReactNode } from "react"
+
+export function generateMetadata(): Metadata {
+  return settings.metadata.wallet
+}
+
+export default function CryptoLayout({ children }: { children: ReactNode }) {
+  return (
+    <PreloadFeatureFlags>
+      <Layout>{children}</Layout>
+    </PreloadFeatureFlags>
+  )
+}

--- a/src/app/crypto/page.tsx
+++ b/src/app/crypto/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { AccountWidget } from "@defuse-protocol/defuse-sdk"
+import { Button } from "@radix-ui/themes"
+import Paper from "@src/components/Paper"
+import { LIST_TOKENS } from "@src/constants/tokens"
+import { useConnectWallet } from "@src/hooks/useConnectWallet"
+import { useTokenList } from "@src/hooks/useTokenList"
+import { renderAppLink } from "@src/utils/renderAppLink"
+import Link from "next/link"
+
+export default function CryptoPage() {
+  const { state } = useConnectWallet()
+  const tokenList = useTokenList(LIST_TOKENS)
+
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <header className="px-3 pt-2">
+        <h1 className="text-lg font-bold">Crypto</h1>
+        <div className="flex gap-6 mt-2 text-sm">
+          <span className="font-bold">Portfolio</span>
+          <span className="text-gray-11">Summary</span>
+          <span className="text-gray-11">Coins</span>
+        </div>
+      </header>
+
+      <Paper>
+        <AccountWidget
+          tokenList={tokenList}
+          userAddress={(state.isVerified ? state.address : undefined) ?? null}
+          userChainType={state.chainType ?? null}
+          renderHostAppLink={renderAppLink}
+        />
+      </Paper>
+
+      <div className="flex justify-around px-3 pb-4">
+        <Link href="/deposit">
+          <Button variant="soft" radius="full">Deposit</Button>
+        </Link>
+        <Link href="/withdraw">
+          <Button variant="soft" radius="full">Withdraw</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navbar/NavbarDesktop.tsx
+++ b/src/components/Navbar/NavbarDesktop.tsx
@@ -10,20 +10,20 @@ import Link from "next/link"
 export function NavbarDesktop() {
   const { isActive } = useIsActiveLink()
 
-  const isAccountActive = isActive(navigation.account)
-  const isTradeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isWalletActive = isActive(navigation.account)
+  const isHomeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isCryptoActive = isActive(navigation.crypto)
 
   return (
     <nav className="flex justify-between items-center gap-4">
-      {/* Account */}
-      <NavItem
-        label="Account"
-        isActive={isAccountActive}
-        href={navigation.account}
-      />
+      {/* Home */}
+      <NavItem label="Home" isActive={isHomeActive} href={navigation.home} />
 
-      {/* Trade */}
-      <NavItem label="Trade" isActive={isTradeActive} href={navigation.home} />
+      {/* Crypto */}
+      <NavItem label="Crypto" isActive={isCryptoActive} href={navigation.crypto} />
+
+      {/* Wallet */}
+      <NavItem label="Wallet" isActive={isWalletActive} href={navigation.account} />
     </nav>
   )
 }

--- a/src/components/Navbar/NavbarMobile.tsx
+++ b/src/components/Navbar/NavbarMobile.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowsLeftRight, Plus } from "@phosphor-icons/react"
+import { ArrowsLeftRight, Plus, House } from "@phosphor-icons/react"
 import { navigation } from "@src/constants/routes"
 import { useIsActiveLink } from "@src/hooks/useIsActiveLink"
 import { cn } from "@src/utils/cn"
@@ -11,40 +11,59 @@ import type { ReactNode } from "react"
 export function NavbarMobile() {
   const { isActive } = useIsActiveLink()
 
-  const isAccountActive = isActive(navigation.account)
-  const isTradeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isWalletActive = isActive(navigation.account)
+  const isHomeActive = isActive(navigation.home) || isActive(navigation.otc)
+  const isCryptoActive = isActive(navigation.crypto)
   const isDepositActive = isActive(navigation.deposit)
 
   return (
     <>
       <div className="fixed bottom-0 z-50 left-0 md:hidden w-full px-5 pt-3 pb-[max(env(safe-area-inset-bottom,0px),theme(spacing.3))] bg-gray-1 border-t-[1px] border-gray-a3">
         <nav className="flex justify-around items-center gap-4">
-          {/* Account */}
+          {/* Home */}
           <NavItem
-            href={navigation.account}
-            label="Account"
-            isActive={isAccountActive}
+            href={navigation.home}
+            label="Home"
+            isActive={isHomeActive}
             iconSlot={
               <NavItem.DisplayIcon>
-                {<WalletIcon active={isAccountActive} />}
+                <House
+                  className={cn(
+                    "size-4",
+                    isHomeActive ? "text-gray-12" : "text-gray-11"
+                  )}
+                  weight="bold"
+                />
               </NavItem.DisplayIcon>
             }
           />
 
-          {/* Trade */}
+          {/* Crypto */}
           <NavItem
-            href={navigation.home}
-            label="Trade"
-            isActive={isTradeActive}
+            href={navigation.crypto}
+            label="Crypto"
+            isActive={isCryptoActive}
             iconSlot={
               <NavItem.DisplayIcon>
                 <ArrowsLeftRight
                   className={cn(
                     "size-4",
-                    isTradeActive ? "text-gray-12" : "text-gray-11"
+                    isCryptoActive ? "text-gray-12" : "text-gray-11"
                   )}
                   weight="bold"
                 />
+              </NavItem.DisplayIcon>
+            }
+          />
+
+          {/* Wallet */}
+          <NavItem
+            href={navigation.account}
+            label="Wallet"
+            isActive={isWalletActive}
+            iconSlot={
+              <NavItem.DisplayIcon>
+                {<WalletIcon active={isWalletActive} />}
               </NavItem.DisplayIcon>
             }
           />

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,6 +1,7 @@
 export const navigation = {
   home: "/",
   account: "/account",
+  crypto: "/crypto",
   deposit: "/deposit",
   withdraw: "/withdraw",
   otc: "/otc/create-order",
@@ -10,6 +11,7 @@ export const navigation = {
 export type AppRoutes =
   | "home"
   | "account"
+  | "crypto"
   | "deposit"
   | "withdraw"
   | "otc"

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -23,7 +23,7 @@ export async function ThemeProvider({ children }: { children: ReactNode }) {
   const accentColor = accentsColors[tpl]
 
   return (
-    <NextThemesThemeProvider attribute="class">
+    <NextThemesThemeProvider attribute="class" defaultTheme="dark">
       <Theme accentColor={accentColor} hasBackground={false}>
         {children}
       </Theme>


### PR DESCRIPTION
## Summary
- add `crypto` route with portfolio screen
- update navigation to include Home, Crypto, Wallet and Deposit
- default theme is dark

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn typecheck` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn check` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688780d87338833190d7cb3f4890de84